### PR TITLE
Added scope downtime and related functionality

### DIFF
--- a/ddctl
+++ b/ddctl
@@ -2,24 +2,38 @@
 from datadog import initialize, api
 from sys import argv
 from argparse import ArgumentParser
+from pathlib import Path
 
 # Setting up parser
 parser = ArgumentParser()
 parser.add_argument("--config",
                     help="declare path to your ddctl.conf config file",
                     metavar="FILE", default="ddctl.conf")
-parser.add_argument("--query",
-                    help="query datadog for a list of hosts by query",
+parser.add_argument("--host-query", metavar='QUERY',
+                    help="ask datadog for a list of hosts by query",
                     default="_empty_")
-parser.add_argument("--host", help="hostname to mute or unmute. \
+parser.add_argument("--tags-by-host", metavar='HOST',
+                    help="ask datadog for a list of tags by host",
+                    default="_empty_")
+parser.add_argument("--get-all-tags", action="store_true",
+                    help="get all tags in your environment",
+                    default="_empty_")
+parser.add_argument("--host", metavar='HOSTS,...',
+                    help="hostname to mute or unmute. \
                     Comma ',' seperated list for multiple",
                     default="_empty_")
-parser.add_argument("--csv", help="flag to return host list with comma seperation",
+parser.add_argument("--scope", metavar='TAGS,...',
+                    help="scope by tag(s) to schedule downtime. \
+                    Comma ',' seperated list for multiple",
+                    default="_empty_")
+parser.add_argument("--csv", help="flag to return list with comma seperation",
                     action="store_true", default=False)
 parser.add_argument("--force", help="flag to force downtime of host(s) mute",
                     action="store_true", default=False)
 parser.add_argument("--hours", help="how many hour(s) to mute",
                     type=int, default=2)
+parser.add_argument("--id", help="downtime id to delete",
+                    type=int, default=0)
 parser.add_argument("--forever", action="store_true",
                     help="set no end time for mute, this overrides --hours",
                     default=False)
@@ -29,27 +43,43 @@ parser.add_argument("--mute", action="store_true",
 parser.add_argument("--unmute", action="store_true",
                     help="UNmute host and return to normal monitoring",
                     default="_empty_")
+parser.add_argument("--add-downtime", action="store_true",
+                    help="schedule downtime by scope",
+                    default="_empty_")
+parser.add_argument("--list-my-downtimes", action="store_true",
+                    help="list scheduled downtimes owned by you",
+                    default="_empty_")
+parser.add_argument("--list-all-downtimes", action="store_true",
+                    help="list scheduled downtimes owned by anyone",
+                    default="_empty_")
+parser.add_argument("--remove-downtime", action="store_true",
+                    help="remove scheduled downtime by id",
+                    default="_empty_")
 args = parser.parse_args()
-
 
 def api_initialization(config_file):
     # imports
     from configparser import ConfigParser
-    # Pulling in API and APP Token
+    # Pulling in API and APP Token from config
     try:
-        config = ConfigParser()
-        config.read(config_file)
-        api_key = config['ddctl']['api_key']
-        app_key = config['ddctl']['app_key']
+        config_file_check = Path(config_file)
+        if config_file_check.is_file():
+            config = ConfigParser()
+            config.read(config_file)
+            api_key  = config['ddctl']['api_key']
+            app_key  = config['ddctl']['app_key']
+            dd_login = config['ddctl']['dd_login']
+        else:
+            raise SystemExit("Config file not found at {}".format(config_file))
     except Exception as err:
-        raise SystemExit("There was an issue reading the config file.")
-
+        raise SystemExit("I am having a problem reading {} in the config.".format(err))
     # Initialize the connection
     options = {'api_key': api_key, 'app_key': app_key}
     try:
         initialize(**options)
     except Exception as err:
         raise SystemExit("Unable to initialize due to: {}".format(err))
+    return dd_login
 
 def hours_from_now(num_hours):
     # imports
@@ -66,8 +96,8 @@ def mute_host(hostname, FOREVER=False, ENDHOURS=2, FORCE=False):
         ENDHOURS=args.hours
     if args.force:
         FORCE=True
-    # Initialize API for use
-    api_initialization(args.config)
+    # Initialize API for use and grab requestor
+    dd_login = api_initialization(args.config)
     # Mute the host by hostname
     for host in hostname.split(','):
         if host == "":
@@ -75,17 +105,23 @@ def mute_host(hostname, FOREVER=False, ENDHOURS=2, FORCE=False):
         if FOREVER:
             try:
                 if FORCE:
-                    result = api.Host.mute(host, override=True)
+                    result = api.Host.mute(host,
+                            message="scheduled by ddctl for {}".format(dd_login),
+                            override=True)
                 else:
-                    result = api.Host.mute(host)
+                    result = api.Host.mute(host,
+                            message="scheduled by ddctl for {}".format(dd_login))
             except Exception as err:
                 raise SystemExit("Unable to mute {0} due to: {1}".format(host, err))
         else:
             try:
                 if FORCE:
-                    result = api.Host.mute(host, end=hours_from_now(ENDHOURS), override=True)
+                    result = api.Host.mute(host, end=hours_from_now(ENDHOURS),
+                            message="scheduled by ddctl for {}".format(dd_login),
+                            override=True)
                 else:
-                    result = api.Host.mute(host, end=hours_from_now(ENDHOURS))
+                    result = api.Host.mute(host, end=hours_from_now(ENDHOURS),
+                            message="scheduled by ddctl for {}".format(dd_login))
             except Exception as err:
                 raise SystemExit("Unable to mute {0} due to: {1}".format(host, err))
         # Print successful result
@@ -95,8 +131,8 @@ def mute_host(hostname, FOREVER=False, ENDHOURS=2, FORCE=False):
             print("NOTE: {0}".format(result['errors'][0].split('. ')[0] + '.'))
 
 def unmute_host(hostname):
-    # Initialize API for use
-    api_initialization(args.config)
+    # Initialize API for use and grab requestor
+    dd_login = api_initialization(args.config)
     # Unmute the host by hostname
     for host in hostname.split(','):
         if host == "":
@@ -111,9 +147,92 @@ def unmute_host(hostname):
         except KeyError:
             print("NOTE: {0}".format(result['errors'][0]))
 
+def create_downtime(scope, FOREVER=False, ENDHOURS=2):
+    # Initialize API for use and grab requestor
+    dd_login = api_initialization(args.config)
+    # Check arguments
+    if args.forever:
+        FOREVER=True
+    if args.hours is not 2:
+        ENDHOURS=args.hours
+    # Create downtime
+    if FOREVER:
+        try:
+            result = api.Downtime.create(scope=scope, message="scheduled by ddctl for {}".format(dd_login))
+            if not result['active']:
+                raise SystemExit("I don't show the downtime as active. Please investigate.")
+            else:
+                print("Downtime was successfully scheduled that will be in place until removed.")
+        except Exception as err:
+            raise SystemExit("There was an error adding downtimes: {0}".format(err))
+    else:
+        try:
+            result = api.Downtime.create(scope=scope, end=hours_from_now(ENDHOURS), message="scheduled by ddctl for {}".format(dd_login))
+            if not result['active']:
+                raise SystemExit("I don't show the downtime as active. Please investigate.")
+            else:
+                print("Downtime was successfully scheduled.")
+        except Exception as err:
+            raise SystemExit("There was an error adding downtimes: {0}".format(err))
+
+def get_downtimes():
+    # Initialize API for use and grab requestor
+    dd_login = api_initialization(args.config)
+    # List downtimes owned by you
+    if args.list_my_downtimes and args.list_all_downtimes == "_empty_":
+        try:
+            result = api.Downtime.get_all(current_only=True)
+        except Exception as err:
+            raise SystemExit("Unable to get your downtimes due to: {0}".format(err))
+        print("Downtimes created by {}:".format(dd_login))
+        count = 0
+        for downtime in result:
+            if downtime['message'] is not None \
+                and downtime['message'].split()[-1] == dd_login:
+                count += 1
+                print("Scope: '{scope}' has id: {id}"
+                    .format(scope=downtime['scope'],
+                    id=downtime['id']))
+        if count == 0:
+            print("None.")
+    # Get all downtimes
+    if args.list_all_downtimes and args.list_my_downtimes == "_empty_":
+        try:
+            result = api.Downtime.get_all(current_only=True)
+        except Exception as err:
+            raise SystemExit("Unable to get all downtimes due to: {0}".format(err))
+        if len(result) > 0:
+            for downtime in result:
+                print("Scope: '{scope}', Monitor: '{mon}' has id: {id}"
+                    .format(scope=downtime['scope'],
+                    mon="-" if downtime['monitor_id'] is None else \
+                        api.Monitor.get(downtime['monitor_id'])['name'],
+                    id=downtime['id']))
+        else:
+            print("There are no current downtimes.".format(dd_login))
+            raise SystemExit(0)
+
+def remove_downtime(id):
+    # Initialize API for use and grab requestor
+    dd_login = api_initialization(args.config)
+    # Delete the downtime
+    try:
+        api.Downtime.delete(id)
+    except Exception as err:
+        raise SystemExit("Ran into an issue removing downtime '{id}': {err}".format(id=id, err=err))
+    # Confirm the downtime was deleted
+    try:
+        result = api.Downtime.get(id)
+        if result['active']:
+            raise SystemExit("ERROR: I still show the downtime as active for {id}.".format(id=id))
+        else:
+            print("Downtime monitor delete request was successful.")
+    except Exception as err:
+        raise SystemExit("Ran into an issue confirming downtime delete was successful: {err}".format(id=id, err=err))
+
 def search_for_host(query, CSV=False):
     # Initialize API for use
-    api_initialization(args.config)
+    dd_login = api_initialization(args.config)
     # Search for host by keywords
     try:
         result = api.Infrastructure.search(q='hosts:{0}'.format(query))
@@ -123,18 +242,68 @@ def search_for_host(query, CSV=False):
     if args.csv:
         CSV=True
     if CSV and len(result['results']['hosts']) > 1:
-        print(",".join(result['results']['hosts']))
+        print(",".join(sorted(result['results']['hosts'])))
     else:
-        for host in result['results']['hosts']:
+        for host in sorted(result['results']['hosts']):
             print(host)
+
+def get_all_tags():
+    # Initialize API for use
+    dd_login = api_initialization(args.config)
+    # Return all tags in environment in json blob
+    try:
+        result = api.Tag.get_all()
+        for tag in sorted(result['tags']):
+            print(tag)
+    except Exception as err:
+        raise SystemExit("Unable to get all tags due to: {0}".format(err))
+
+def get_tags_by_host(host):
+    # Initialize API for use
+    dd_login = api_initialization(args.config)
+    # Return all tags in environment in json blob
+    try:
+        result = api.Tag.get(host)
+        for tag in sorted(result['tags']):
+            print(tag)
+    except Exception as err:
+        raise SystemExit("Unable to get tags for host {0} due to: {1}".format(host, err))
 
 def _main():
     if len(argv) < 2:
         parser.print_help()
         raise SystemExit(1)
 
-    if not args.query == "_empty_":
-        search_for_host(args.query)
+    if not args.host_query == "_empty_":
+        search_for_host(args.host_query)
+
+    if not args.get_all_tags == "_empty_":
+        get_all_tags()
+
+    if not args.tags_by_host == "_empty_":
+        get_tags_by_host(args.tags_by_host)
+
+    if not args.list_my_downtimes == "_empty_":
+        if args.list_all_downtimes == "_empty_":
+            get_downtimes()
+        else:
+            raise SystemExit("ERROR: Only expecting 1 downtime question at a time")
+
+    if not args.list_all_downtimes == "_empty_":
+        if args.list_my_downtimes == "_empty_":
+            get_downtimes()
+        else:
+            raise SystemExit("ERROR: Only expecting 1 downtime question at a time")
+
+    if not args.add_downtime == "_empty_":
+        if args.scope == "_empty_":
+            raise SystemExit("Scope argument is required when addding downtime")
+        create_downtime(args.scope)
+
+    if not args.remove_downtime == "_empty_":
+        if args.id == 0:
+            raise SystemExit("delete downtime argument requires a valid id argument")
+        remove_downtime(args.id)
 
     if not args.mute == "_empty_":
         if args.host == "_empty_":

--- a/ddctl.conf.example
+++ b/ddctl.conf.example
@@ -1,3 +1,4 @@
 [ddctl]
-api_key = 9775a026f1ca7d1c6c5af9d94d9595a4
-app_key = 87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+api_key  = 9775a026f1ca7d1c6c5af9d94d9595a4
+app_key  = 87ce4a24b5553d2e482ea8a8500e71b8ad4554ff
+dd_login = user@example.com


### PR DESCRIPTION
ddctl you can now:
1. Query for hosts
2. Mute hosts with sane defaults
3. Mute hosts and specify number of hours or forever
4. Un-mute hosts
5. Query for tags related to a host
6. Get *ALL* tags
7. Add Downtime with sane defaults with comma separated scope
8. Add Downtime that will last  for specific number of hours or forever with comma separated scope
9. List Downtimes created by you via ddctl and return scope and id
10. List *ALL* Downtimes that includes their scope, monitor (if applicable) and id
11. Remove Downtimes by id

Will update README in another MR. 