### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ddctl - Simple Datadog Control
 #### Requirements
-* `pip install -r requirements.txt`
+* Python 3 - on ubuntu: `sudo apt-get install python3-pip`
+* `pip3 install -r requirements.txt`
 * API and APP key from Datadog
 
 #### Setup config for Datadog API


### PR DESCRIPTION
To non python folks such as myself it wasn't immediately obvious that `ddctl` requires python3. This helps make it clear. 